### PR TITLE
cert manager migrate to azure workload identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,4 @@ Examples for this module along with various configurations can be found in the [
 | 2025-10-20 | v2.0.2  | Pin minimum version of azurerm to 4.49.0                                                                            |
 | 2025-12-24 | v2.0.3  | Federated identity credential setup for Velero                                                                      |
 | 2026-01-06 | v2.0.4  | Add additional permissions for velero operations                                                                    |
+| 2026-01-08 | v2.0.5  | Federated identity credential setup for Cert Manager                                                                |

--- a/README.md
+++ b/README.md
@@ -70,3 +70,4 @@ Examples for this module along with various configurations can be found in the [
 | 2025-12-24 | v2.0.3  | Federated identity credential setup for Velero                                                                      |
 | 2026-01-06 | v2.0.4  | Add additional permissions for velero operations                                                                    |
 | 2026-01-08 | v2.0.5  | Federated identity credential setup for Cert Manager                                                                |
+| 2026-01-09 | v2.0.6  | Define variables to pass oidc issuer url Cert Manager workload identity                                             |

--- a/main.tf
+++ b/main.tf
@@ -37,5 +37,7 @@ module "platform_rg" {
   # platform resources
   bill_of_landing_managed_identity_id = var.bill_of_landing_managed_identity_id
 
+  oidc_issuer_url                  = var.oidc_issuer_url
+
   tags = local.tags
 }

--- a/modules/platform/cert_manager.tf
+++ b/modules/platform/cert_manager.tf
@@ -28,3 +28,16 @@ resource "azurerm_role_assignment" "aad_pod_identity_cert_manager_operator" {
   role_definition_name = "Managed Identity Operator"
   principal_id         = var.cluster_identity_object_id
 }
+
+# Creates a Federate Identity Credential
+#
+# https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential
+#
+resource "azurerm_federated_identity_credential" "cert_manager" {
+  name                = "${module.azure_resource_names.managed_identity_name}-cert-manager"
+  resource_group_name = azurerm_resource_group.platform.name
+  audience            = ["api://AzureADTokenExchange"]
+  issuer              = var.oidc_issuer_url
+  parent_id           = azurerm_user_assigned_identity.cert_manager.id
+  subject             = "system:serviceaccount:cert-manager-system:cert-manager"
+}

--- a/modules/platform/variables.tf
+++ b/modules/platform/variables.tf
@@ -73,3 +73,8 @@ variable "bill_of_landing_managed_identity_id" {
   type        = string
   default     = null
 }
+
+variable "oidc_issuer_url"{
+  description = "The OIDC issuer URL that is associated with the cluster."
+  type        = string
+}


### PR DESCRIPTION
- This PR fixes the missing `oidc_issuer_url ` variable